### PR TITLE
Feature/json endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ $ yarn deploy [--aws-profile <yourProfile>]
 
 ## :information_source: Anything else
 <!-- show how to test, how to contribute -->
-nothing
+Once you deploy Sample Google Search API, you can invoke it like bellow.
+
+```
+$ curl -X POST
+```
 
 ## :pencil: Author
 [mesh1nek0x0](https://github.com/mesh1nek0x0)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ yarn invoke:google-search
 ```
 
 *run test*
+WIP
 ```
 $ yarn test
 ```
@@ -62,7 +63,7 @@ $ yarn test
 $ yarn lint
 ```
 
-*deploy API（Lambda&API Gateway）*
+*deploy sample Google Search API*
 ```
 $ yarn deploy [--aws-profile <yourProfile>]
 ```
@@ -74,8 +75,10 @@ $ yarn deploy [--aws-profile <yourProfile>]
 Once you deploy Sample Google Search API, you can invoke it like bellow.
 
 ```
-$ curl -X POST
+$ curl https://xxx.execute-api.your-region.amazonaws.com/dev/mascare/google-search -X POST -d '{"TOKEN": "update-this-token", "text": "hoge"}'
 ```
+
+you can see the result in Cloud Watch Logs @
 
 ## :pencil: Author
 [mesh1nek0x0](https://github.com/mesh1nek0x0)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint src",
     "test": "jest --config=jest.config.json",
     "invoke": "sls invoke local -f google-search-endpoint",
-    "invoke:google": "sls invoke local -f google-search"
+    "invoke:google": "sls invoke local -f google-search",
+    "deploy": "sls deploy"
+
   },
   "devDependencies": {
     "aws-sdk": "^2.326.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "lint": "eslint src",
     "test": "jest --config=jest.config.json",
-    "invoke": "sls invoke local -f google-serach-endpoint",
-    "invoke:google": "sls invoke local -f google-serach"
+    "invoke": "sls invoke local -f google-search-endpoint",
+    "invoke:google": "sls invoke local -f google-search"
   },
   "devDependencies": {
     "aws-sdk": "^2.326.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@
 #
 # Happy Coding!
 
-service: google-serach # NOTE: update this with your service name
+service: mascara-google-search # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
@@ -55,7 +55,7 @@ provider:
 #    - exclude-me-dir/**
 
 functions:
-  google-serach-endpoint:
+  google-search-endpoint:
     handler: src/google-search/handler.index
     role: endopointRole
     events:
@@ -63,7 +63,7 @@ functions:
           path: mascare/google-search
           method: post
 
-  google-serach:
+  google-search:
     handler: src/google-search/main.index
 #    The following are a few example events you can configure
 #    NOTE: Please make sure to change your handler code to work with those events

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,6 +57,8 @@ provider:
 functions:
   google-search-endpoint:
     handler: src/google-search/handler.index
+    environment:
+      TOKEN: update-this-token
     role: endopointRole
     events:
       - http:

--- a/src/google-search/handler.js
+++ b/src/google-search/handler.js
@@ -17,8 +17,8 @@ module.exports.index = async (event, context, callback) => {
 
     const lambda = new AWS.Lambda();
     const params = {
-        FunctionName: 'google-serach-dev-google-serach',
-        ClientContext: 'google-serach-endpoint',
+        FunctionName: 'mascara-google-search-dev-google-search',
+        ClientContext: 'google-search-endpoint',
         InvocationType: 'Event',
         Payload: JSON.stringify({
             args: {"test": "hoge"}

--- a/src/google-search/handler.js
+++ b/src/google-search/handler.js
@@ -4,8 +4,8 @@ const AWS = require('aws-sdk');
 
 module.exports.index = async (event, context, callback) => {
     console.log(context);
-    const token = JSON.parse(event.body).TOKEN;
-    if (token != process.env.TOKEN) {
+    const req = JSON.parse(event.body);
+    if (req.TOKEN != process.env.TOKEN) {
         return {
             statusCode: 400,
             body: JSON.stringify({
@@ -21,7 +21,7 @@ module.exports.index = async (event, context, callback) => {
         ClientContext: 'google-search-endpoint',
         InvocationType: 'Event',
         Payload: JSON.stringify({
-            args: {"test": "hoge"}
+            "searchWord": req.text
         }),
     };
 


### PR DESCRIPTION
## PR内容
検索ワードを指定して、google検索をサーバレスでスクレイピングするサンプルを追加しました

APIのエンドポイントのレスポンスは202ですが、
検索結果はCloudWatchのログから確認できます。

##  変更点
- SmapleのAPIのcurlでの呼び出し方法を追記
- 検索ワードを指定できるように変更